### PR TITLE
Unpublish posts using wp_schedule_single_event

### DIFF
--- a/unpublish.php
+++ b/unpublish.php
@@ -24,9 +24,10 @@ class Unpublish {
 		if ( empty( self::$instance ) ) {
 			self::$instance = new Unpublish;
 			// Standard setup methods
-			foreach( array( 'setup_variables', 'includes', 'setup_actions' ) as $method ) {
-				if ( method_exists( self::$instance, $method ) )
+			foreach ( array( 'setup_variables', 'includes', 'setup_actions' ) as $method ) {
+				if ( method_exists( self::$instance, $method ) ) {
 					self::$instance->$method();
+				}
 			}
 		}
 		return self::$instance;
@@ -233,9 +234,10 @@ class Unpublish {
 		global $_wp_post_type_features;
 
 		$post_types = array();
-		foreach( $_wp_post_type_features as $post_type => $features ) {
-			if ( ! empty( $features[self::$supports_key] ) )
-				$post_types[]= $post_type;
+		foreach ( $_wp_post_type_features as $post_type => $features ) {
+			if ( ! empty( $features[ self::$supports_key ] ) ) {
+				$post_types[] = $post_type;
+			}
 		}
 
 		$args = array(
@@ -249,14 +251,14 @@ class Unpublish {
 					'meta_value'  => current_time( 'timestamp' ),
 					'compare'     => '<',
 					'type'        => 'NUMERIC',
-					),
+				),
 				array(
 					'meta_key'    => self::$post_meta_key,
 					'meta_value'  => current_time( 'timestamp' ),
 					'compare'     => 'EXISTS',
-					)
-				)
-			);
+				),
+			),
+		);
 		$query = new WP_Query( $args );
 
 		if ( $query->have_posts() ) {

--- a/unpublish.php
+++ b/unpublish.php
@@ -106,11 +106,21 @@ class Unpublish {
 	}
 
 	/**
+	 *  Get post unpublish timestamp
+	 *
+	 *  @param  int    $post_id Post ID.
+	 *  @return string Timestamp.
+	 */
+	private function get_unpublish_timestamp( $post_id ) {
+		return get_post_meta( $post_id, self::$post_meta_key, true );
+	}
+
+	/**
 	 * Render the UI for changing the unpublish time of a post
 	 */
 	public function render_unpublish_ui() {
 
-		$unpublish_timestamp = get_post_meta( get_the_ID(), self::$post_meta_key, true );
+		$unpublish_timestamp = $this->get_unpublish_timestamp( get_the_ID() );
 		if ( ! empty( $unpublish_timestamp ) ) {
 			$local_timestamp = strtotime( get_date_from_gmt( date( 'Y-m-d H:i:s', $unpublish_timestamp ) ) );
 			$datetime_format = sprintf( __( '%s @ %s', 'unpublish' ), $this->date_format, $this->time_format );

--- a/unpublish.php
+++ b/unpublish.php
@@ -13,7 +13,7 @@ Domain Path: /languages
 class Unpublish {
 
 	public static $supports_key = 'unpublish';
-	public static $old_cron_key = 'unpublish_cron';
+	public static $deprecated_cron_key = 'unpublish_cron';
 	public static $cron_key = 'unpublish_post_cron';
 	public static $post_meta_key = 'unpublish_timestamp';
 
@@ -61,8 +61,8 @@ class Unpublish {
 		add_action( 'load-post-new.php', array( self::$instance, 'action_load_customizations' ) );
 		add_action( self::$cron_key, array( self::$instance, 'unpublish_post' ) );
 
-		if ( wp_next_scheduled( self::$old_cron_key ) ) {
-			add_action( self::$old_cron_key, array( self::$instance, 'unpublish_content' ) );
+		if ( wp_next_scheduled( self::$deprecated_cron_key ) ) {
+			add_action( self::$deprecated_cron_key, array( self::$instance, 'unpublish_content' ) );
 		}
 	}
 
@@ -268,7 +268,7 @@ class Unpublish {
 			}
 		} else {
 			// There are no posts scheduled to unpublish, we can safely remove the old cron.
-			wp_clear_scheduled_hook( self::$old_cron_key );
+			wp_clear_scheduled_hook( self::$deprecated_cron_key );
 		}
 	}
 

--- a/unpublish.php
+++ b/unpublish.php
@@ -224,6 +224,13 @@ class Unpublish {
 	 * @param int $post_id Post ID.
 	 */
 	public function unpublish_post( $post_id ) {
+		$unpublish_timestamp = (int) $this->get_unpublish_timestamp( $post_id );
+
+		if ( $unpublish_timestamp > time() ) {
+			$this->schedule_unpublish( $post_id, $unpublish_timestamp );
+			return;
+		}
+
 		wp_trash_post( $post_id );
 	}
 

--- a/unpublish.php
+++ b/unpublish.php
@@ -112,14 +112,15 @@ class Unpublish {
 
 		$unpublish_timestamp = get_post_meta( get_the_ID(), self::$post_meta_key, true );
 		if ( ! empty( $unpublish_timestamp ) ) {
+			$local_timestamp = strtotime( get_date_from_gmt( date( 'Y-m-d H:i:s', $unpublish_timestamp ) ) );
 			$datetime_format = sprintf( __( '%s @ %s', 'unpublish' ), $this->date_format, $this->time_format );
-			$unpublish_date  = date_i18n( $datetime_format, $unpublish_timestamp );
+			$unpublish_date  = date_i18n( $datetime_format, $local_timestamp );
 			$date_parts      = array(
-				'jj' => date( 'd', $unpublish_timestamp ),
-				'mm' => date( 'm', $unpublish_timestamp ),
-				'aa' => date( 'Y', $unpublish_timestamp ),
-				'hh' => date( 'H', $unpublish_timestamp ),
-				'mn' => date( 'i', $unpublish_timestamp ),
+				'jj' => date( 'd', $local_timestamp ),
+				'mm' => date( 'm', $local_timestamp ),
+				'aa' => date( 'Y', $local_timestamp ),
+				'hh' => date( 'H', $local_timestamp ),
+				'mn' => date( 'i', $local_timestamp ),
 			);
 		} else {
 			$unpublish_date = '&mdash;';
@@ -199,7 +200,7 @@ class Unpublish {
 			return;
 		}
 
-		$timestamp = strtotime( $unpublish_date );
+		$timestamp = strtotime( get_gmt_from_date( $unpublish_date ) );
 
 		update_post_meta( $post_id, self::$post_meta_key, $timestamp );
 		$this->schedule_unpublish( $post_id, $timestamp );

--- a/unpublish.php
+++ b/unpublish.php
@@ -59,11 +59,18 @@ class Unpublish {
 		add_action( 'load-post-new.php', array( self::$instance, 'action_load_customizations' ) );
 
 		if ( ! wp_next_scheduled( self::$cron_key ) ) {
-			wp_schedule_event( time(), $this->cron_frequency, self::$cron_key );
+			$this->upgrade_scheduling();
 		}
+	}
 
-		add_action( self::$cron_key, array( self::$instance, 'unpublish_content' ) );
-
+	/**
+	 *  Upgrade scheduling
+	 *
+	 *  // TODO
+	 */
+	private function upgrade_scheduling() {
+		// wp_schedule_event( time(), $this->cron_frequency, self::$cron_key );
+		// add_action( self::$cron_key, array( self::$instance, 'unpublish_content' ) );
 	}
 
 	/**


### PR DESCRIPTION
The old and new events will run side by side. When the old event is run and there are no posts with unpublish dates found, it will clear the old schedule.

Fixes #8.

