### PR TITLE
Fix scheduling

### DIFF
--- a/unpublish.php
+++ b/unpublish.php
@@ -286,7 +286,10 @@ class Unpublish {
 	 */
 	public function schedule_unpublish( $post_id, $timestamp ) {
 		$this->unschedule_unpublish( $post_id );
-		wp_schedule_single_event( $timestamp, self::$cron_key, array( $post_id ) );
+
+		if ( $timestamp > current_time( 'timestamp', true ) ) {
+			wp_schedule_single_event( $timestamp, self::$cron_key, array( $post_id ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Before scheduling, ensure that the unpublish timestamp is after the current time.

Fixes #24.