### PR TITLE
Add 'auth_callback' argument to register_meta()

### DIFF
--- a/inc/post-meta.php
+++ b/inc/post-meta.php
@@ -32,7 +32,7 @@ function register_meta( string $post_type ) : void {
 		'show_in_rest'  => true,
 		'single'        => true,
 		'type'          => 'integer',
-		'auth_callback' => function () {
+		'auth_callback' => function() {
 			return current_user_can( 'edit_posts' );
 		},
 	] );

--- a/inc/post-meta.php
+++ b/inc/post-meta.php
@@ -28,10 +28,13 @@ function register_meta( string $post_type ) : void {
 	}
 
 	register_post_meta( $post_type, Unpublish\POST_META_KEY, [
-		'description'  => __( 'Unpublish time', 'unpublish' ),
-		'show_in_rest' => true,
-		'single'       => true,
-		'type'         => 'integer',
+		'description'   => __( 'Unpublish time', 'unpublish' ),
+		'show_in_rest'  => true,
+		'single'        => true,
+		'type'          => 'integer',
+		'auth_callback' => function () {
+			return current_user_can( 'edit_posts' );
+		},
 	] );
 }
 


### PR DESCRIPTION
Because the 'unpublish_timestamp' meta key is marked as protected:
https://github.com/humanmade/Unpublish/blob/21a3126fc8d468ffefbdf204a102ed956dc9fb16/inc/post-meta.php#L17

No one is able to update the unpublish timestamp by default in the REST API and hence, the Block Editor:
https://github.com/WordPress/WordPress/blob/5affd982a05df50af14104e466c26822974475f0/wp-includes/meta.php#L1339-L1346

This commit adds the `'auth_callback'` argument in the `register_meta()` call and uses `current_user_can( 'edit_posts' )` to determine whether the current user can update the unpublish timestamp.