### PR TITLE
Fix fatal error for Post_Meta hook return type

### DIFF
--- a/inc/post-meta.php
+++ b/inc/post-meta.php
@@ -43,17 +43,17 @@ function register_meta( string $post_type ) : void {
  * @param string $meta_key   Meta key.
  * @param mixed  $meta_value Meta value.
  *
- * @return bool
+ * @return void
  */
-function update_schedule( int $meta_id, int $object_id, string $meta_key, $meta_value ) : bool {
+function update_schedule( int $meta_id, int $object_id, string $meta_key, $meta_value ) : void {
 	if ( $meta_key !== Unpublish\POST_META_KEY ) {
-		return false;
+		return;
 	}
 
 	if ( $meta_value ) {
-		return Unpublish\schedule_unpublish( $object_id, absint( $meta_value ) );
+		Unpublish\schedule_unpublish( $object_id, absint( $meta_value ) );
 	} else {
-		return Unpublish\unschedule_unpublish( $object_id );
+		Unpublish\unschedule_unpublish( $object_id );
 	}
 }
 

--- a/inc/post-meta.php
+++ b/inc/post-meta.php
@@ -63,15 +63,11 @@ function update_schedule( int $meta_id, int $object_id, string $meta_key, $meta_
  * @param int[]  $meta_ids   An array of deleted metadata entry IDs.
  * @param int    $object_id  Object ID.
  * @param string $meta_key   Meta key.
- *
- * @return bool
  */
-function remove_schedule( array $meta_ids, int $object_id, string $meta_key ) : bool {
+function remove_schedule( array $meta_ids, int $object_id, string $meta_key ) : void {
 	if ( $meta_key === Unpublish\POST_META_KEY ) {
-		return Unpublish\unschedule_unpublish( $object_id );
+		Unpublish\unschedule_unpublish( $object_id );
 	}
-
-	return false;
 }
 
 /**


### PR DESCRIPTION
This PR switches the return type for `Post_Meta\remove_schedule()` and `Post_Meta\update_schedule()` from `bool` to `void` because those functions:

* Are hooked to an action, not a filter; and
* Returns `Unpublish\unschedule_unpublish()`, which can be an integer, not a bool:

https://github.com/humanmade/Unpublish/blob/21a3126fc8d468ffefbdf204a102ed956dc9fb16/inc/namespace.php#L42-L48

This can throw the following fatal error when deleting or updating a post that has an unpublish timestamp:

```
PHP Fatal error: Uncaught TypeError: Return value of HM\Unpublish\Post_Meta\remove_schedule() must be of the type bool, int returned in /wp-content/plugins/Unpublish/inc/post-meta.php:71

Stack trace:
#0 /wp-includes/class-wp-hook.php(289): HM\Unpublish\Post_Meta\remove_schedule(Array, 354, 'unpublish_times...')
#1 /wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters(NULL, Array)
#2 /wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#3 /wp-includes/meta.php(965): do_action('deleted_post_me...', Array, 354, 'unpublish_times...', '1602519250')
#4 /wp-includes/post.php(3066): delete_metadata_by_mid('post', 1046)
#5 /wp-admin/post.php(318): wp_delete_post(354, true)
#6 {main} thrown in /wp-content/plugins/Unpublish/inc/post-meta.php on line 71
```